### PR TITLE
Add docker compose v2 instruction

### DIFF
--- a/docs/contributor-guide/developer-guide/getting-started.md
+++ b/docs/contributor-guide/developer-guide/getting-started.md
@@ -13,11 +13,13 @@ Start here! This step is a prerequisite for everything that follows, even if you
 
 1. Download [Docker Desktop](https://www.docker.com/get-started). On Mac, run Docker Desktop and go to Preferences > Resources to increase max RAM for containers to at least 4GB (ideally 6GB), otherwise sbt compiles can get killed before completing and produce strange runtime behavior.
 
+1. (Linux only) Install Docker compose v2 by following [these instructions](https://docs.docker.com/compose/cli-command/#install-on-linux)
+
 1. Clone the CiviForm repo. This will create a copy of the codebase on your machine:
 
     1. Open a terminal and navigate to the directory you'd like the copy of the CiviForm codebase to live.
 
-    1. In that directory, run the following (and/or refer to
+    2. In that directory, run the following (and/or refer to
        [this guide](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)):
 
            git clone git@github.com:seattle-uat/civiform.git


### PR DESCRIPTION
Linux users need to install the docker compose v2 plugin 

This will only be necessary [until compose v2 is GA](https://docs.docker.com/compose/cli-command/#transitioning-to-ga-for-compose-v2)