### PR TITLE
Add instructions to add browser test for new question types

### DIFF
--- a/docs/contributor-guide/developer-guide/adding-a-new-question-type.md
+++ b/docs/contributor-guide/developer-guide/adding-a-new-question-type.md
@@ -35,4 +35,5 @@
     1. Applicant flow
         1. Can you fill out the question?
         1. Do error messages render correctly
-1. Add a helper function in the browser tests for the new question type: [`admin_question.ts`](https://github.com/seattle-uat/civiform/blob/main/browser-test/src/support/admin_questions.ts)
+1. Add a helper function in the browser tests for the new question type: [`admin_question.ts`](https://github.com/seattle-uat/civiform/blob/main/browser-test/src/support/admin_questions.ts) and [`applicant_questions.ts`](https://github.com/seattle-uat/civiform/blob/main/browser-test/src/support/applicant_questions.ts)
+1. Add a focused browser test for the new question type: e.g. [`checkbox.test.ts`](https://github.com/seattle-uat/civiform/blob/main/browser-test/src/checkbox_test.ts)


### PR DESCRIPTION
We now have browser tests for every question type as part of https://github.com/seattle-uat/civiform/issues/1937