### PR TITLE
Few fixes to terraform deployment guide.

### DIFF
--- a/docs/it-manual/sre-playbook/terraform-deploy-system.md
+++ b/docs/it-manual/sre-playbook/terraform-deploy-system.md
@@ -13,22 +13,22 @@ You will need couple of values that are configured outside of Civiform before yo
 
 1. Fork the [civiform-deploy](https://github.com/civiform/civiform-deploy) repo to your organization via the UI
 2. Pull the repo onto the machine you are deploying from (ideally this would be a shared instance multiple people can log onto)
-3. Run the bin/doctor and install the dependencies
-4. Copy the civiform\_config.example.sh into civiform\_config.sh and fill out the missing values. You can get a sense of required values depending on your cloud provider by looking at [staging-azure](https://github.com/civiform/staging-azure-deploy/blob/main/civiform_config.sh) or [staging-aws](https://github.com/civiform/staging-aws-deploy/blob/main/civiform_config.sh) configs.
-5. Find the version that you want to deploy on [Github](https://github.com/civiform/civiform/releases)
-6. Run bin/setup --tag=\<version>
+3. Find the version that you want to deploy on [Github](https://github.com/civiform/civiform/releases)
+4. Run the `bin/doctor --tag=<version>` and install the dependencies
+5. Copy the civiform\_config.example.sh into civiform\_config.sh and fill out the missing values. You can get a sense of required values depending on your cloud provider by looking at [staging-azure](https://github.com/civiform/staging-azure-deploy/blob/main/civiform_config.sh) or [staging-aws](https://github.com/civiform/staging-aws-deploy/blob/main/civiform_config.sh) configs.
+6. Run `bin/setup --tag=<version>`
 
 
 ## Deploy
 
 1. Find the version that you want to deploy on [Github](https://github.com/civiform/civiform/releases)
-2. Run bin/deploy --tag=\<version>
+2. Run `bin/deploy --tag=<version>`
 
 ## Troubleshooting
 
 #### Terraform fails
 
-The deploy command is idempotent so if it fails try running it again. The setup command can also be re-reun but it does re-set a lot of variables which are kind of a pain to continually set up.
+The deploy command is idempotent so if it fails try running it again. The setup command can also be re-run but it does re-set a lot of variables which are kind of a pain to continually set up when you run it for Azure.
 
 If changes were made upstream, you can change the code in the checkout env, but will need to commit PRs to fix in the main repo
 
@@ -61,18 +61,18 @@ The setup scrip prompts you to set up Azure AD. There are a few additional steps
 * To allow for civiform admins you need to have the Azure Ad return the groups claim. Do this in the token configuration section of the Azure portal and add the security groups claim (you can verify the groups claim is being returned by decoding the base64 token from the token you get back from Azure AD on the website-- if you preserve the log in the Chrome Dev Tool window it should be from https://\<custom\_hostname>/callback/AdClient)
 
 
-### Access the database
+### Access the database (only Azure)
 
 1. cd checkout
 2. cloud/azure/bin/db-connection -g sgdev -d civiform-artistic-halibut -v sgdev-civiform-kv
 
-### Restore data to the database from a dump file
+### Restore data to the database from a dump file (only Azure)
 
 1. If on WSL figure out what the location of the dump file (possibly /mnt/c/..)
 2. cd checkout
 3. cloud/azure/bin/pg-restore -g sgdev -d civiform-artistic-halibut -v sgdev-civiform-kv -f /mnt/c/pg\_dump.dump -b testData.dump
 
-### Clear data from the database
+### Clear data from the database (only Azure)
 1. cd checkout 
 2. From checkout directory run `cloud/azure/bin/db-connection -d <database_name> -g <resource_group> -v <keyvault>`
 Note that the database_name does not include the .postgres.database 


### PR DESCRIPTION
1. `bin/doctor` requires passing tag at the moment. So adding it there.
2. Typo fixes.