### PR TITLE
Update releasing.md

### DIFF
--- a/docs/contributor-guide/developer-guide/releasing.md
+++ b/docs/contributor-guide/developer-guide/releasing.md
@@ -95,4 +95,4 @@ If Matthew is not available, recruit engineers, PMs, and other contributors to e
 
 ### 5. Publish the release and email all stakeholders
 
-Once the release notes are looking good, publish the draft release and then email the release notes to civiform-technical@googlegroups.com
+Once the release notes are looking good, publish the draft release and then email the release notes to civiform-announce@googlegroups.com


### PR DESCRIPTION
Civiform-technical is closed group while civiform-announce is public. Releases should be publicly announced as it's an open source application.