### PR TITLE
Update docs to use localhost.localstack.cloud host for accessing localstack

### DIFF
--- a/docs/contributor-guide/developer-guide/dev-testing.md
+++ b/docs/contributor-guide/developer-guide/dev-testing.md
@@ -19,7 +19,7 @@ You should now be logged in as a named Applicant.  You can re-login as that appl
 
 ## Email
 
-Sent emails can be viewed at: http://localstack:4566/_localstack/ses
+Sent emails can be viewed at: http://localhost.localstack.cloud:4566/_localstack/ses
 
 To view the output nicer you can use the [JSON Formatter](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en) extension
 

--- a/docs/contributor-guide/developer-guide/file-storage-backend.md
+++ b/docs/contributor-guide/developer-guide/file-storage-backend.md
@@ -8,7 +8,9 @@ File upload functionality uses the Azurite / Localstack emulators. For Azure-bas
 
 ```
 127.0.0.1 azurite
-127.0.0.1 localstack
+127.0.0.1 localhost.localstack.cloud
+# Required for test AWS S3 bucket
+127.0.0.1 civiform-local-s3.localhost.localstack.cloud
 ```
 
 This is because the application makes requests to Azurite using its container name, which can only be resolved when the request is made from within the Docker network. These container names to be mapped to the loopback IP address in order for the browser to resolve requests to `azurite` to upload and get uploaded images.

--- a/docs/contributor-guide/developer-guide/getting-started.md
+++ b/docs/contributor-guide/developer-guide/getting-started.md
@@ -103,7 +103,9 @@ For login and file upload to work with your local server, you need to edit your 
 ```
 127.0.0.1 dev-oidc
 127.0.0.1 azurite
-127.0.0.1 localstack
+127.0.0.1 localhost.localstack.cloud
+# Required for test AWS S3 bucket
+127.0.0.1 civiform-local-s3.localhost.localstack.cloud
 ```
 This provides a local IP route for the 'dev-oidc', 'azurite', and 'localstack' hostnames.
 


### PR DESCRIPTION
This matches what is used in tests and official Localstack docs.