### PR TITLE
Add IntelliJ troubleshooting for routes issue

### DIFF
--- a/docs/contributor-guide/developer-guide/getting-started.md
+++ b/docs/contributor-guide/developer-guide/getting-started.md
@@ -42,6 +42,11 @@ This setup will only include the files under (.../server), therefore, if you wou
 * Ensure `civiform-server` and `sources` are selected in second and third column,
 * Click on + on the right handside to add all folders under civiform except "server" to the content roots 
 
+If you still have trouble getting some symbols to show (such as `routes` packages), try the following:
+
+1. Go to Preferences, then "Languages and Frameworks", then "Scala".
+2. Switch Error Highlighting from "Built-in" to "Compiler".
+
 #### Configuring VSCode
 
 **Setup**


### PR DESCRIPTION
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/30369272/217594727-16a66397-1b27-4606-abc5-3b082cae4179.png">

I was frustrated by the issue above with the `.routes` package not being recognized by IntelliJ, which made a significant number of my files have red lines suggesting they do not compile. The workaround described in this PR fixes that.