### PR TITLE
updating oncall docs

### DIFF
--- a/docs/contributor-guide/developer-guide/releasing.md
+++ b/docs/contributor-guide/developer-guide/releasing.md
@@ -1,8 +1,8 @@
 # Releasing
 
-See [Upgrading to a New Release](it-manual/sre-playbook/upgrading-to-a-new-release.md) for an overview of CiviForm release practices.
+See [Upgrading to a New Release](../../it-manual/sre-playbook/upgrading-to-a-new-release.md) for an overview of CiviForm release practices.
 
-Releases are created weekly by the on-call engineer on Wednesday before 12pm. The on-call engineer may use the production meeting time to create the release if desired. Out-of-schedule releases may be created if requested by a civic entity (e.g. for an urgent bugfix).
+Releases are created weekly by the on-call engineer on Wednesday before 12pm Pacific Time. The on-call engineer may use the production meeting time to create the release if desired. Out-of-schedule releases may be created if requested by a civic entity (e.g. for an urgent bugfix).
 
 New releases go through a QA process that takes them from a draft state to fully published. The QA process is best-effort for official release images, and may be skipped if resources are not available.
 
@@ -115,4 +115,4 @@ If Matthew is not available, recruit engineers, PMs, and other contributors to e
 
 ### 5. Publish the release notes and email all stakeholders
 
-Once the release notes are looking good, publish the draft notes and then email the release notes to civiform-announce@googlegroups.com
+Once the release notes are looking good, publish the draft notes (click the edit button and then "Publish" at the bottom of the screen) and then email the release notes to civiform-announce@googlegroups.com and civiform-technical@googlegroups.com

--- a/docs/governance-and-management/project-management/on-call-guide/README.md
+++ b/docs/governance-and-management/project-management/on-call-guide/README.md
@@ -14,6 +14,9 @@ Join the CiviForm GitHub repo ([https://github.com/civiform/civiform](https://gi
 
 Also join the CiviForm GitHub org ([https://github.com/civiform](https://github.com/civiform)).
 
+
+TODO: is this still true?
+
 NOTE: the mainline project repo existing under the `seattle-uat` GitHub org is temporary. Once Seattle no longer depends on deployment automation from the mainline repo you will only need to be an admin of https://github.com/civiform.
 
 #### Ensure you have visibility into comms
@@ -41,21 +44,24 @@ Check if there are any current urgent bugs. If there are, make sure you know wha
 
 ### On-call responsibilities
 
-1. Respond to downstream production incidents (daily)
+1. [Generate a release](../../../contributor-guide/developer-guide/releasing.md) on Wednesday by 12pm Pacific Time
+2. Respond to downstream production incidents (daily)
    * Check GitHub [issue tracker](https://github.com/civiform/civiform/issues)
    * Check [civiform-technical@googlegroups.com](https://groups.google.com/g/civiform-technical)
-2. Check security mailing lists for new vulnerability reports (daily)
+3. Check security mailing lists for new vulnerability reports (daily)
    * [Play Framework security announcement group](https://groups.google.com/g/play-framework-security)
    * [OpenJDK security announcement mailing list](https://mail.openjdk.java.net/mailman/listinfo/vuln-announce)
    * [pac4j security announcement mailing list](https://groups.google.com/g/pac4j-security)
-3. Check [dependency updates](https://github.com/civiform/civiform/labels/dependencies) (once per shift)
-4. Check security updates at [Codecov](https://about.codecov.io/security-update)
+4. Monitor staging deployments in the [#ci](https://app.slack.com/client/T01Q6PJQAES/C03UXPUEXU4) Slack channel. Investigate failed deployments and re-run if appropriate. (Note: our browser tests can be flakey and case deployments to fail. If this is the case, re-running the deployment will often fix the issue.)
+4. Check [dependency updates](https://github.com/civiform/civiform/labels/dependencies) (once per shift)
+5. Check security updates at [Codecov](https://about.codecov.io/security-update)
+6. Create an oncall issue for the next rotation using the [Oncall Issue Template](https://github.com/civiform/civiform/blob/main/.github/ISSUE_TEMPLATE/oncall-rotation.md)
 
 #### Downstream production incident support
 
 The top priority for the on-caller is addressing urgent needs from downstream deployments of CiviForm. An urgent need is an outage, privacy, or security incident caused by bugs in the CiviForm application or deployment code. When an incident occurs it may not be clear what the root cause is and whether or not it is ultimately the responsibility of the upstream project to resolve it. Assume it is though until proven otherwise.
 
-Incidents may be reported in a variety of ways. Since they're coming from civic entities and not Google internal staff or tooling we have limited control over this. At a minimum you should monitor:
+Incidents may be reported in a variety of ways. Since they're coming from civic entities and not Google or Exygy internal staff or tooling we have limited control over this. At a minimum you should monitor:
 
 * Bugs filed in the GitHub issues tracker
 * Emails to civiform-technical@googlegroups.com
@@ -67,7 +73,7 @@ Tip: Your primary responsibility with respect to incident response is to triage 
 
 #### Security vulnerability fixes
 
-In open source software development, it's common for library maintainers to release updates when a new security vulnerability is discovered. Subscribe to the security mailing lists mentioned in the Preparation section. If you receive an advisory during your on-call shift, respond to it by creating an issue in GitHub and triaging it appropriately.
+In open source software development, it's common for library maintainers to release updates when a new security vulnerability is discovered. Subscribe to the security mailing lists mentioned in the [Preparation section](#ensure-you-have-visibility-into-comms). If you receive an advisory during your on-call shift, respond to it by creating an issue in GitHub and triaging it appropriately.
 
 The most common response will be to update the appropriate dependency to the latest patch version that includes a fix.
 

--- a/docs/governance-and-management/project-management/on-call-guide/README.md
+++ b/docs/governance-and-management/project-management/on-call-guide/README.md
@@ -14,11 +14,6 @@ Join the CiviForm GitHub repo ([https://github.com/civiform/civiform](https://gi
 
 Also join the CiviForm GitHub org ([https://github.com/civiform](https://github.com/civiform)).
 
-
-TODO: is this still true?
-
-NOTE: the mainline project repo existing under the `seattle-uat` GitHub org is temporary. Once Seattle no longer depends on deployment automation from the mainline repo you will only need to be an admin of https://github.com/civiform.
-
 #### Ensure you have visibility into comms
 
 * Join the CiviForm public Slack org (https://civiform.slack.com), [join link](https://join.slack.com/t/civiform/shared\_invite/zt-niap7ys1-RAICICUpDJfjpizjyjBr7Q)
@@ -55,7 +50,9 @@ Check if there are any current urgent bugs. If there are, make sure you know wha
 4. Monitor staging deployments in the [#ci](https://app.slack.com/client/T01Q6PJQAES/C03UXPUEXU4) Slack channel. Investigate failed deployments and re-run if appropriate. (Note: our browser tests can be flakey and case deployments to fail. If this is the case, re-running the deployment will often fix the issue.)
 4. Check [dependency updates](https://github.com/civiform/civiform/labels/dependencies) (once per shift)
 5. Check security updates at [Codecov](https://about.codecov.io/security-update)
-6. Create an oncall issue for the next rotation using the [Oncall Issue Template](https://github.com/civiform/civiform/blob/main/.github/ISSUE_TEMPLATE/oncall-rotation.md)
+6. Create an oncall issue for the next rotation using the [Oncall Issue Template](https://github.com/civiform/civiform/blob/main/.github/ISSUE_TEMPLATE/oncall-rotation.md) and close the oncall issue assigned to you.
+7. Update the [Oncall Journal](on-call-journal.md) with anything that happened during your shift that you think might be helpful for future on-callers to know.
+8. If you come accross an issue that could use a playbook or further documentation, create a github issue to track that additional documentation is needed. Assign it to yourself or the next oncaller if you don't have capacity.
 
 #### Downstream production incident support
 

--- a/docs/it-manual/sre-playbook/upgrading-to-a-new-release.md
+++ b/docs/it-manual/sre-playbook/upgrading-to-a-new-release.md
@@ -1,6 +1,6 @@
 # Upgrading to a New Release
 
-The CiviForm core team [distributes new versions of the system](https://github.com/civiform/civiform/releases) at least monthly, and occasionally more often. We strongly recommend deployments stay up to date with the latest version to benefit from security patches, bug fixes, and new features.
+The CiviForm core team [distributes new versions of the system](https://github.com/civiform/civiform/releases) once per week on Wednesdays. We strongly recommend deployments stay up to date with the latest version to benefit from security patches, bug fixes, and new features.
 
 Each release is published using [GitHub releases](https://github.com/civiform/civiform/releases) with a corresponding server Docker image uploaded to [civiform/civiform on Docker Hub](https://hub.docker.com/repository/docker/civiform/civiform) and tagged with the release number.
 


### PR DESCRIPTION
Edits to the Oncall and Release docs including:
- fixed links
- removed outdated info
- added additional steps to Oncall responsibilities