### PR TITLE
update programs table schema with new columns

### DIFF
--- a/docs/contributor-guide/developer-guide/database/db-schema.md
+++ b/docs/contributor-guide/developer-guide/database/db-schema.md
@@ -128,28 +128,31 @@ Indexes:
     "index_persisted_durable_jobs_by_execution_time" btree (execution_time)
     "index_persisted_durable_jobs_by_success_time" btree (success_time)
 
-                                                 Table "public.programs"
-            Column            |            Type             | Collation | Nullable |               Default                
-------------------------------+-----------------------------+-----------+----------+--------------------------------------
- id                           | bigint                      |           | not null | nextval('programs_id_seq'::regclass)
- name                         | character varying           |           |          | 
- description                  | character varying           |           |          | 
- block_definitions            | jsonb                       |           | not null | 
- export_definitions           | jsonb                       |           |          | 
- legacy_localized_name        | jsonb                       |           |          | 
- legacy_localized_description | jsonb                       |           |          | 
- slug                         | character varying           |           |          | 
- localized_name               | jsonb                       |           |          | 
- localized_description        | jsonb                       |           |          | 
- external_link                | character varying           |           |          | ''::character varying
- display_mode                 | character varying           |           | not null | 'PUBLIC'::character varying
- create_time                  | timestamp without time zone |           |          | 
- last_modified_time           | timestamp without time zone |           |          | 
- status_definitions           | jsonb                       |           |          | '{"statuses": []}'::jsonb
+                                                  Table "public.programs"
+             Column             |            Type             | Collation | Nullable |               Default
+--------------------------------+-----------------------------+-----------+----------+--------------------------------------
+ id                             | bigint                      |           | not null | nextval('programs_id_seq'::regclass)
+ name                           | character varying           |           |          |
+ description                    | character varying           |           |          |
+ block_definitions              | jsonb                       |           | not null |
+ legacy_localized_name          | jsonb                       |           |          |
+ legacy_localized_description   | jsonb                       |           |          |
+ slug                           | character varying           |           |          |
+ localized_name                 | jsonb                       |           |          |
+ localized_description          | jsonb                       |           |          |
+ external_link                  | character varying           |           |          | ''::character varying
+ display_mode                   | character varying           |           | not null | 'PUBLIC'::character varying
+ create_time                    | timestamp without time zone |           |          |
+ last_modified_time             | timestamp without time zone |           |          |
+ status_definitions             | jsonb                       |           |          | '{"statuses": []}'::jsonb
+ program_type                   | character varying           |           |          | 'default'::character varying
+ eligibility_is_gating          | boolean                     |           |          | true
+ localized_confirmation_message | jsonb                       |           |          |
 Indexes:
     "programs_pkey" PRIMARY KEY, btree (id)
 Referenced by:
     TABLE "applications" CONSTRAINT "fk_program" FOREIGN KEY (program_id) REFERENCES programs(id)
+
                                             Table "public.questions"
           Column           |        Type         | Collation | Nullable |                Default
 ---------------------------+---------------------+-----------+----------+---------------------------------------


### PR DESCRIPTION
Two new columns were added to the programs table recently: `localized_confirmation_message` and `eligibility_is_gating`. This PR updates our db schema page to include those columns.

Question: I'm only updated the programs table because I made changes to the programs table, but this is making me wonder what else on this page might be out of date. Is the printout of the db helpful on this page and should we keep it? If so, how do we make sure it stays up to date?