### PR TITLE
Update demography export settings text

### DIFF
--- a/docs/user-manual/civiform-admin-guide/download-exported-data.md
+++ b/docs/user-manual/civiform-admin-guide/download-exported-data.md
@@ -1,11 +1,11 @@
-# How to download exported data
+# How to export demographic data
 
-Watch the video or follow the step-by-step guide below to download all applications for all programs into a CSV file:
+Watch the video or follow the step-by-step guide below to download the demography export for all applications for all programs into a CSV file:
 
 1. Navigate to the programs page by clicking **Programs** in the navigation bar.
-2. Click the **Download Exported Data (CSV)** button.
+2. Click the **Download Demographic Data (CSV)** button.
 3. Select a date range for the data you'd like to export. If you select a large date range or leave it blank, the data could be slow to export.
-4. Click the **Download Exported Data (CSV)** to begin the export.
+4. Click the **Download Demographic Data (CSV)** to begin the export.
 5. You will see the CSV file downloaded onto your computer.
 
 {% embed url="https://drive.google.com/file/d/1bfqU3hQPUFJytpvi6qdUnMmVSipJTTLN/view?usp=sharing" %}

--- a/docs/user-manual/civiform-admin-guide/manage-questions.md
+++ b/docs/user-manual/civiform-admin-guide/manage-questions.md
@@ -21,11 +21,11 @@ Watch the video or follow the step-by-step guide below.
 
 When a CiviForm Admin creates a question, they must choose an export setting. The export setting controls whether data will be exported in the demography CSV, which is the CiviForm Admin's exported data. The export setting does not affect the Program Admin's exported data. The CiviForm Admin selects one of the following data export options:
 
-**Don't allow answers to be exported** - the answer won't appear in any way in the exported data.
+**Don't include in demographic export** - the answer won't appear in any way in the exported data.
 
-**Export exact answers** - the raw answer as provided by the applicant will appear in the exported data.
+**Include in demographic export** - the raw answer as provided by the applicant will appear in the exported data.
 
-**Export obfuscated answers** - the raw answer as provided by the applicant will not appear in the exported data, and instead, an "obfuscated" answer will appear. Obfuscated means that the applicant's answer to the question is cryptographically obscured, exporting text that is unique to the applicant's answer but does not reveal what the original text was. It is impossible to derive the applicant's original input from the resulting exported value. Only other questions with the exact same answer will have the same exported value. 
+**Obfuscate and include in demographic export** - the raw answer as provided by the applicant will not appear in the exported data, and instead, an "obfuscated" answer will appear. Obfuscated means that the applicant's answer to the question is cryptographically obscured, exporting text that is unique to the applicant's answer but does not reveal what the original text was. It is impossible to derive the applicant's original input from the resulting exported value. Only other questions with the exact same answer will have the same exported value. 
 
 For example, in a social security number question, the following inputs would result in the corresponding outputs: 
 


### PR DESCRIPTION
Clarify description of question data export settings

Updates the text admins see when setting data privacy settings for questions, to clarify that they only affect the demography export, not the API.

This is part of https://github.com/civiform/civiform/issues/5347