### PR TITLE
Remove story-acceptance channel from communications guide

### DIFF
--- a/docs/governance-and-management/governance/communication.md
+++ b/docs/governance-and-management/governance/communication.md
@@ -48,7 +48,6 @@ we should reassess this approach.
 | **\#prox-management**               | For PM and UX discussions                                    | PMs, UX                                                                    |
 | **\#new-contributors**              | For questions by new contributors to the codebase.           | Software Engineers                                                         |
 | **\#civic-entity (e.g. \#seattle)** | For topic-specific discussions with a given civic entity.    | Anyone from the specified civic entity and their designated collaborators. |
-| **\#story-acceptance**              | *This channel is currently live but is not used.*            |                                                                            |
 
 Slack Norms:
 


### PR DESCRIPTION
This channel is archived so it should not be listed.