### PR TITLE
Update notes on admin writeable vars

### DIFF
--- a/docs/it-manual/sre-playbook/server-environment-variables/README.md
+++ b/docs/it-manual/sre-playbook/server-environment-variables/README.md
@@ -12,7 +12,7 @@ left sidebar to see the available configuration variables for the CiviForm
 version you are deploying.
 
 Variables can have four different modes which determine where they are set and displayed:
-1. "Admin writeable" variables should be set in the admin settings panel which is accessible in CiviForm when logged in as an admin. These variables should NOT be set in your deployment config and setting them there will have no affect on the app.
+1. "Admin writeable" variables should be set in the admin settings panel which is accessible in CiviForm when logged in as an admin. These variables should NOT be set in your deployment config and setting them there will result in a deployment error. If you need to set custom values for Admin writeable variables during an intial deploy, it is possible to override this error by setting `export ALLOW_ADMIN_WRITEABLE=true` in your deploy config. This should only be used for the initial deploy and should be removed from the config immediately afterwards.
 2. "Admin readable" variables should be set in your deployment config file. The values for these variables can be seen in the admin settings panel, but not changed there.
 3. "Server setting" variables should be set in your deployment config file and are not visible in the admin settings panel.
 4. "Managed secret" variables should be set in your cloud provider's secrets manager. These are not visible in the admin settings panel.


### PR DESCRIPTION
With the changes introduced in https://github.com/civiform/cloud-deploy-infra/pull/318, including ADMIN_WRITEABLE vars in the deploy config will throw an error. This PR updates the docs to reflect this.