### PR TITLE
Add API docs for file_urls

### DIFF
--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -533,7 +533,6 @@ _Note_: This property is deprecated and soon to be replaced by `file_urls`. It i
 #### `file_urls`
 - **Property**: `file_urls`
 - **JSON Type**: `[string]`
-- **Format**: A URL, or an empty array `[]` if unanswered.
 - **Format**: An array of URLs, or an empty array `[]` if unanswered.
 - **Description**: An array of links to the file the applicant uploaded.\
 _Note_: This link is not a link to the file that can be used programatically. It's a link that requires a Program Admin login to retrieve the file.

--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -528,12 +528,13 @@ In addition to the metadata field, file upload questions have the following prop
 - **JSON Type**: `string` or `null`
 - **Format**: A URL, `null` if unanswered.
 - **Description**: A link to the file the applicant uploaded.\
-_Note_: This property is deprecated and soon to be replaced by `file_urls`.
+_Note_: This property is deprecated and soon to be replaced by `file_urls`. It is not included if the MULTIPLE_FILE_UPLOAD_ENABLED flag is turned on.
 
 #### `file_urls`
 - **Property**: `file_urls`
 - **JSON Type**: `[string]`
 - **Format**: A URL, or an empty array `[]` if unanswered.
+- **Format**: An array of URLs, or an empty array `[]` if unanswered.
 - **Description**: An array of links to the file the applicant uploaded.\
 _Note_: This link is not a link to the file that can be used programatically. It's a link that requires a Program Admin login to retrieve the file.
 

--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -528,6 +528,13 @@ In addition to the metadata field, file upload questions have the following prop
 - **JSON Type**: `string` or `null`
 - **Format**: A URL, `null` if unanswered.
 - **Description**: A link to the file the applicant uploaded.\
+_Note_: This property is deprecated and soon to be replaced by `file_urls`.
+
+#### `file_urls`
+- **Property**: `file_urls`
+- **JSON Type**: `[string]`
+- **Format**: A URL, `[]` if unanswered.
+- **Description**: An array of links to the file the applicant uploaded.\
 _Note_: This link is not a link to the file that can be used programatically. It's a link that requires a Program Admin login to retrieve the file.
 
 An file upload question looks like
@@ -536,7 +543,8 @@ An file upload question looks like
 ```json
 "proof_of_income" : {
   "question_type" : "FILE_UPLOAD",
-  "file_key" : "https://my.civiform.gov/file_key.pdf"
+  "file_key" : "https://my.civiform.gov/file_key.pdf",
+  "file_urls" : [ "https://my.civiform.gov/file_key.pdf" ]
 },
 ```
 {% endcode %}

--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -533,7 +533,7 @@ _Note_: This property is deprecated and soon to be replaced by `file_urls`.
 #### `file_urls`
 - **Property**: `file_urls`
 - **JSON Type**: `[string]`
-- **Format**: A URL, `[]` if unanswered.
+- **Format**: A URL, or an empty array `[]` if unanswered.
 - **Description**: An array of links to the file the applicant uploaded.\
 _Note_: This link is not a link to the file that can be used programatically. It's a link that requires a Program Admin login to retrieve the file.
 


### PR DESCRIPTION
Add API docs for file_urls (in preparation for multiple file uploads.)

This documents both properties for now, using a single file. Once we launch, we'll remove file_key and we'll also change the example to include multiple files.