### PR TITLE
Update links in FAQ and About buttons

### DIFF
--- a/website/public/about/index.html
+++ b/website/public/about/index.html
@@ -250,7 +250,7 @@
             to learn more about bringing CiviForm to your community:
           </p>
           <p>
-            <a href="/contact" class="btn-action-primary m-t-1"
+            <a href="/getstarted-new" class="btn-action-primary m-t-1"
               ><span class="btn-action-title">Get started</span
               ><span class="btn-action-text"
                 >Bring CiviForm to your community</span

--- a/website/public/faq/index.html
+++ b/website/public/faq/index.html
@@ -304,8 +304,11 @@
                   Adopting CiviForm requires working closely with program
                   administrators, IT teams, and other stakeholders to
                   successfully understand and meet the needs of programs and
-                  residents. See "<a href="/contact">Get started</a>" for a
-                  detailed look at the process.
+                  residents. See "<a href="/getstarted-new">Get Started</a>" for
+                  an overview. If you want more detail, visit the "<a
+                    href="/implementation-guide"
+                    >Implementation Guide</a
+                  >" for a detailed look at the process.
                 </p>
               </div>
             </details>

--- a/website/src/about.md
+++ b/website/src/about.md
@@ -13,7 +13,7 @@ CiviForm is a free, open source software solution for governments that was devel
 
 Read more about CiviForm's key features below and in our [documentation](https://docs.civiform.us), and reach out to learn more about bringing CiviForm to your community:
 
-<a href="/contact" class="btn-action-primary m-t-1"><span class="btn-action-title">Get started</span><span class="btn-action-text">Bring CiviForm to your community</span></a>
+<a href="/getstarted-new" class="btn-action-primary m-t-1"><span class="btn-action-title">Get started</span><span class="btn-action-text">Bring CiviForm to your community</span></a>
 
 ## Developed and trusted by:
 

--- a/website/src/faq.md
+++ b/website/src/faq.md
@@ -34,7 +34,7 @@ title: CiviForm | FAQ
   <details open>
     <summary>How can I get CiviForm in my community?</summary>
     <div class="accordion-body">
-    <p>Adopting CiviForm requires working closely with program administrators, IT teams, and other stakeholders to successfully understand and meet the needs of programs and residents. See "<a href="/contact">Get started</a>" for a detailed look at the process.</p>
+    <p>Adopting CiviForm requires working closely with program administrators, IT teams, and other stakeholders to successfully understand and meet the needs of programs and residents. See "<a href="/getstarted-new">Get Started</a>" for an overview. If you want more detail, visit the "<a href="/implementation-guide">Implementation Guide</a>" for a detailed look at the process.</p>
     </div>
   </details>
 </cagov-accordion>


### PR DESCRIPTION
### Description

Update "Get Started" link to /getstarted-new and add "Implementation Guide" link in FAQ "How can I get CiviForm in my community?" answer

Update "Get Started" link to /getstarted-new in About page button