### PR TITLE
Change case for Get Started in nav bar

### DIFF
--- a/website/public/about/index.html
+++ b/website/public/about/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/contact-new/index.html
+++ b/website/public/contact-new/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/contact/index.html
+++ b/website/public/contact/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/deploymentguide/index.html
+++ b/website/public/deploymentguide/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/faq/index.html
+++ b/website/public/faq/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/getstarted-new/index.html
+++ b/website/public/getstarted-new/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="/css/index.css" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <script type="module" src="/js/index.js"></script>
-    <title>CiviForm | Get started</title>
+    <title>CiviForm | Get Started</title>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-SPPGE89TM8"
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>
@@ -221,7 +221,7 @@
     <div id="page-container" class="page-container-ds">
       <div id="main-content" class="main-content-ds single-column">
         <main id="body-content">
-          <h1>Get started</h1>
+          <h1>Get Started</h1>
           <p>
             To get started learning how to deploy CiviForm in your organization,
             <br />use this guide to learn what steps are needed at each stage of
@@ -287,7 +287,7 @@
           <a href="/implementation-guide" class="btn-action-primary m-t-1"
             ><span class="btn-action-title">Implementation Guide</span
             ><span class="btn-action-text"
-              >For more details, see our implementation guide</span
+              >For more details, see our Implementation Guide</span
             ></a
           >
         </main>

--- a/website/public/implementation-guide/index.html
+++ b/website/public/implementation-guide/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/learnmore/index.html
+++ b/website/public/learnmore/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/public/news/index.html
+++ b/website/public/news/index.html
@@ -136,7 +136,7 @@
                   ><a
                     class="expanded-menu-section-header-link js-event-hm-menu"
                     href="/getstarted-new"
-                    >Get started</a
+                    >Get Started</a
                   ></strong
                 >
               </div>

--- a/website/src/_includes/layouts/navigation.njk
+++ b/website/src/_includes/layouts/navigation.njk
@@ -37,7 +37,7 @@
               ><a
                 class="expanded-menu-section-header-link js-event-hm-menu"
                 href="/getstarted-new"
-                >Get started</a
+                >Get Started</a
               ></strong
             >
           </div>

--- a/website/src/getstarted-new.md
+++ b/website/src/getstarted-new.md
@@ -1,8 +1,8 @@
 ---
 layout: layouts/page.njk
-title: CiviForm | Get started
+title: CiviForm | Get Started
 ---
-# Get started
+# Get Started
 
 To get started learning how to deploy CiviForm in your organization, <br>use this guide to learn what steps are needed at each stage of implementation.
 
@@ -52,4 +52,4 @@ To get started learning how to deploy CiviForm in your organization, <br>use thi
     </div>
   </div>
 </div>
-<a href="/implementation-guide" class="btn-action-primary m-t-1"><span class="btn-action-title">Implementation Guide</span><span class="btn-action-text">For more details, see our implementation guide</span></a>
+<a href="/implementation-guide" class="btn-action-primary m-t-1"><span class="btn-action-title">Implementation Guide</span><span class="btn-action-text">For more details, see our Implementation Guide</span></a>


### PR DESCRIPTION
Changed case for Get Started in nav bar and Get Started page from "Get started" to "Get Started"

Changed case for "Implementation Guide" in button on "Get Started" page

