### PR TITLE
Add note about pre-screener not being migrated

### DIFF
--- a/docs/user-manual/civiform-admin-guide/program-migration.md
+++ b/docs/user-manual/civiform-admin-guide/program-migration.md
@@ -44,6 +44,7 @@ There are a few program and question settings that are not yet being migrated ov
 - Any categories assigned to the program
 - TI groups associated with the program
 - Primary Applicant Info settings applied to questions
+- "pre-screener" setting on a program
 
 ## Potential Errors
 


### PR DESCRIPTION
### Description

Added the "pre-screener" setting to the list of settings not migrated.

### Checklist

#### General

- [x] Ensure any links to pages aren't referenced in code (if there are changes to links)
- [x] Changes to the website have been verified via steps [here](https://github.com/civiform/docs/blob/main/README.md#1-run-the-website-locally)

### Issue(s) this completes

Related to https://github.com/civiform/civiform/issues/8652
