### PR TITLE
DOM text reinterpreted as HTML Update index.js

### DIFF
--- a/website/public/js/index.js
+++ b/website/public/js/index.js
@@ -89,7 +89,7 @@
       document.querySelector(".cagov-nav.menu-trigger").classList.add("is-fixed");
       document.querySelector(".cagov-nav.menu-trigger").setAttribute("aria-expanded", "true");
       const menLabel = document.querySelector(".cagov-nav.menu-trigger-label");
-      menLabel.innerHTML = menLabel.getAttribute("data-closelabel");
+      menLabel.textContent = menLabel.getAttribute("data-closelabel");
     }
     closeMainMenu() {
       document.querySelector(".mobile-icons").classList.remove("display-menu");


### PR DESCRIPTION
### Description

By using textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.

### Checklist

#### General

- [ ] Ensure any links to pages aren't referenced in code (if there are changes to links)
- [ ] Changes to the website have been verified via steps [here](https://github.com/civiform/docs/tree/main/website#1-run-the-website-locally)

