### PR TITLE
Update release info to say Tuesday or Wednesday

### DIFF
--- a/docs/it-manual/sre-playbook/upgrading-to-a-new-release.md
+++ b/docs/it-manual/sre-playbook/upgrading-to-a-new-release.md
@@ -1,6 +1,6 @@
 # Upgrading to a New Release
 
-The CiviForm core team [distributes new versions of the system](https://github.com/civiform/civiform/releases) once per week on Tuesdays. We strongly recommend deployments stay up to date with the latest version to benefit from security patches, bug fixes, and new features.
+The CiviForm core team [distributes new versions of the system](https://github.com/civiform/civiform/releases) once per week on Tuesdays or Wednesdays. We strongly recommend deployments stay up to date with the latest version to benefit from security patches, bug fixes, and new features.
 
 Each release is published using [GitHub releases](https://github.com/civiform/civiform/releases) with a corresponding server Docker image uploaded to [civiform/civiform on Docker Hub](https://hub.docker.com/repository/docker/civiform/civiform) and tagged with the release number.
 


### PR DESCRIPTION
### Description

Updated our release info to reflect our new policy of publishing a release on Tuesdays or Wednesdays

Based on discussion in our eng weekly meeting on 3/3/25. [See notes](https://docs.google.com/spreadsheets/d/1jXuOWl9TxssHh3A1AkmKi2gva9LRUhE0PQStJa-4yWs/edit?gid=1246619714#gid=1246619714)

Fyi I didn't update the instructions [here](https://github.com/civiform/docs/blob/5e4bcf07814ce46323a68b70156013afb379dabe/docs/governance-and-management/project-management/on-call-guide/README.md#L45) because they say to draft a release by Tuesday, 12pm PT which is still true. The only thing changing is the criteria for when we publish a release.

Corresponding internal wiki update [here](https://github.com/civiform/civiform/wiki/Releasing/_compare/10902d3af4b4927cd8555958d222d4c1316edf74)
Corresponding on-call issue update [here](https://github.com/civiform/civiform/pull/9876)
