### PR TITLE
Add note about requiring unique group names

### DIFF
--- a/docs/user-manual/civiform-admin-guide/manage-trusted-intermediaries.md
+++ b/docs/user-manual/civiform-admin-guide/manage-trusted-intermediaries.md
@@ -11,7 +11,7 @@ Watch the video or follow the step-by-step guide below.
 
 1. Sign in to CiviForm as a CiviForm Admin.
 2. Click **Intermediaries** on the navigation bar.
-3. Enter information for the group.
+3. Enter information for the group (**Note**: The group name should be unique).
 4. Click **Create**.\
    The new group appears in the list of groups.
 


### PR DESCRIPTION
### Description

This doc update is a response to https://github.com/civiform/civiform/pull/10098, which requires that new TI group names be unique from existing TI group names. Existing groups are not affected.