### PR TITLE
Add time filter to list applications API documentation

### DIFF
--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -22,7 +22,7 @@ All query parameters are optional, but case-sensitive.
 #### `fromDate`
 - **Parameter**: `fromDate`
 - **Format**: An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).
-- **Description**:Limits results to applications submitted on or after the provided date. Uses the CiviForm instance's local timezone when no timezone is provided, and the beginning of the day when no time is provided.
+- **Description**: Limits results to applications submitted on or after the provided date. Uses the CiviForm instance's local timezone when no timezone is provided, and the beginning of the day when no time is provided.
 
 #### `toDate`
 - **Parameter**: `toDate`

--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -21,13 +21,13 @@ All query parameters are optional, but case-sensitive.
 
 #### `fromDate`
 - **Parameter**: `fromDate`
-- **Format**: An ISO-8601 formatted date (i.e. YYYY-MM-DD).
-- **Description**: Limits results to applications submitted on or after the provided date, in the CiviForm instance's local time.
+- **Format**: An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).
+- **Description**:Limits results to applications submitted on or after the provided date. Uses the CiviForm instance's local timezone when no timezone is provided, and the beginning of the day when no time is provided.
 
 #### `toDate`
 - **Parameter**: `toDate`
-- **Format**: An ISO-8601 formatted date (i.e. YYYY-MM-DD).
-- **Description**: Limits results to applications submitted before the provided date, in the CiviForm instance's local time.
+- **Format**: An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).
+- **Description**: Limits results to applications submitted before the provided date. Uses the CiviForm instance's local timezone when no timezone is provided, and the beginning of the day when no time is provided.
 
 #### `pageSize`
 - **Parameter**: `pageSize`


### PR DESCRIPTION
### Description

Timestamps were added to the `fromDate` and `toDate` params in list applications API on #10636. This updates the documentation for it

### Checklist

#### General

- [ ] Ensure any links to pages aren't referenced in code (if there are changes to links)
- [ ] Changes to the website have been verified via steps [here](https://github.com/civiform/docs/tree/main/website#1-run-the-website-locally)

### Issue(s) this completes

Fixes [#5483](https://github.com/civiform/civiform/issues/5483)
