### PR TITLE
Add revision state param to applications API documentation

### DIFF
--- a/docs/it-manual/api/program-applications.md
+++ b/docs/it-manual/api/program-applications.md
@@ -29,6 +29,11 @@ All query parameters are optional, but case-sensitive.
 - **Format**: An ISO-8601 formatted date-time with zone id (i.e. YYYY-MM-DDTThh:mm:ssZ).
 - **Description**: Limits results to applications submitted before the provided date. Uses the CiviForm instance's local timezone when no timezone is provided, and the beginning of the day when no time is provided.
 
+#### `revisionState`
+- **Parameter**: `revisionState`
+- **Format**: A string representing the `RevisionState` [enum](https://github.com/civiform/civiform/blob/main/server/app/services/export/enums/RevisionState.java), currently coinsisting of one of `OBSOLETE` or `CURRENT`.
+- **Description**: The revision state of applications to include in results. `CURRENT` indicates this is the most recent version of the application. `OBSOLETE` indicates this application has been superseded by a newer submission. When omitted, applications of all revision states are returned.
+
 #### `pageSize`
 - **Parameter**: `pageSize`
 - **Format**: A positive integer.


### PR DESCRIPTION
### Description

Revision state parameter was added to list applications API in [#10747](https://github.com/civiform/civiform/pull/10747). This updates the documentation for it

### Checklist

#### General

- [ ] Ensure any links to pages aren't referenced in code (if there are changes to links)
- [ ] Changes to the website have been verified via steps [here](https://github.com/civiform/docs/tree/main/website#1-run-the-website-locally)

### Issue(s) this completes

Part of [#499](https://github.com/civiform/civiform/issues/499)
